### PR TITLE
Reduce cardinality of logging fields

### DIFF
--- a/cmd/address/parse.go
+++ b/cmd/address/parse.go
@@ -32,7 +32,7 @@ func ParseHandler(ctx echo.Context) error {
 	parsed := postal.ParseAddressOptions(input.Query, options)
 
 	// Build the response.
-	logger.WithField("input", input).WithField("output_count", len(parsed)).Info("OK")
+	logger.Infof('Parsed input "%s" into %d fields.', input, len(parsed))
 	response := make(map[string]interface{})
 	for _, entry := range parsed {
 		response[entry.Label] = entry.Value

--- a/cmd/google/place.go
+++ b/cmd/google/place.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Initialise the logger.
-var baseLogger = log.WithFields(logging.RunningStage()).WithFields(logging.GoogleComponent())
+var logger = log.WithFields(logging.RunningStage()).WithFields(logging.GoogleComponent())
 
 // PlaceHandler handles the /google/place route.
 func PlaceHandler(c echo.Context) error {
@@ -24,9 +24,6 @@ func PlaceHandler(c echo.Context) error {
 		return ctx.NoContent(http.StatusBadRequest)
 	}
 
-	// Augment the logger.
-	logger := baseLogger.WithField("placeId", id)
-
 	// Attempt to get the place details from the database cache.
 	if ctx.DB != nil {
 		placeDetails, err := ctx.DB.FindPlaceDetailsById(id)
@@ -36,7 +33,7 @@ func PlaceHandler(c echo.Context) error {
 
 		// If the place details were found, return them to the client.
 		if placeDetails != nil {
-			logger.WithField("source", "db").Info("Found place details in cache.")
+			logger.WithField("source", "db").Infof("Fetched place details for %s from cache.", id)
 			return ctx.JSON(http.StatusOK, placeDetails)
 		}
 	}
@@ -47,7 +44,7 @@ func PlaceHandler(c echo.Context) error {
 		return err
 	}
 
-	logger.WithField("source", "api").Info("Fetched place details from Google API.")
+	logger.WithField("source", "api").Infof("Fetched place details for %s from Google API.", id)
 
 	// Store the place details in the database.
 	if ctx.DB != nil {


### PR DESCRIPTION
Instead of having everything as fields in structured logging, reduce the cardinality by passing some variables in the message.