### PR TITLE
Expose current version via header

### DIFF
--- a/cmd/health.go
+++ b/cmd/health.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/thepieterdc/gopos/internal/pkg/version"
 	"github.com/thepieterdc/gopos/pkg/health"
-	"github.com/thepieterdc/gopos/version"
 	"net/http"
 )
 

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION the current application version.
-var VERSION = "2.1.3-SNAPSHOT"
+const VERSION = "2.1.3-SNAPSHOT"

--- a/main.go
+++ b/main.go
@@ -41,8 +41,9 @@ func main() {
 	cmd.RegisterGoogleRoutes(srv)
 	srv.GET("/timezone", cmd.TimezoneHandler)
 
-	// Register the custom context.
+	// Register custom middleware.
 	srv.Use(web.ContextMiddleware(db))
+	srv.Use(web.VersionHeaderMiddleware)
 
 	// Register the prometheus middleware.
 	prom := prometheus.NewPrometheus("gopos", nil)

--- a/pkg/web/middleware.go
+++ b/pkg/web/middleware.go
@@ -2,8 +2,12 @@ package web
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/thepieterdc/gopos/internal/pkg/version"
 	"github.com/thepieterdc/gopos/pkg/database"
 )
+
+// HeaderVersion HTTP Header that includes the current version.
+const HeaderVersion = "X-Gopos-Version"
 
 // GoposContext custom context that exposes the database instance to routes.
 type GoposContext struct {
@@ -19,5 +23,14 @@ func ContextMiddleware(db *database.Database) echo.MiddlewareFunc {
 			cc := &GoposContext{DB: db, Context: ctx}
 			return next(cc)
 		}
+	}
+}
+
+// VersionHeaderMiddleware adds the current Gopos version to every HTTP
+// response.
+func VersionHeaderMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		ctx.Response().Header().Set(HeaderVersion, version.VERSION)
+		return next(ctx)
 	}
 }

--- a/scripts/increment-version.sh
+++ b/scripts/increment-version.sh
@@ -8,12 +8,12 @@ usage() {
 }
 
 # Check if the version file exists.
-if [ ! -f version/version.go ]; then
+if [ ! -f internal/pkg/version/version.go ]; then
     usage
 fi
 
 # Get the current version.
-version=$(cat version/version.go | grep 'VERSION = ' | grep -o '".*"$' | tr -d '"')
+version=$(cat internal/pkg/version/version.go | grep 'VERSION = ' | grep -o '".*"$' | tr -d '"')
 
 # Strip the optional -SNAPSHOT part.
 if echo "$version" | grep -q "\-SNAPSHOT"; then

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -13,9 +13,9 @@ if [ "$#" -ne 1 ]; then
 fi
 
 # Check if the version file exists.
-if [ ! -f version/version.go ]; then
+if [ ! -f internal/pkg/version/version.go ]; then
     usage
 fi
 
 # Replace the version.
-sed -i "s/VERSION = .*$/VERSION = \"$1\"/g" "version/version.go"
+sed -i "s/VERSION = .*$/VERSION = \"$1\"/g" "internal/pkg/version/version.go"


### PR DESCRIPTION
This PR adds a custom response header to include the current Gopos version in every HTTP response.

```
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
X-Gopos-Version: 2.1.3-SNAPSHOT
Date: Tue, 09 Nov 2021 21:39:49 GMT
Content-Length: 55
```